### PR TITLE
fix: fix wrong cgroup path

### DIFF
--- a/cgroups/controls_cgroups.go
+++ b/cgroups/controls_cgroups.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"reflect"
 
-	com "github.com/ArisAachen/deepin-network-proxy/com"
-	define "github.com/ArisAachen/deepin-network-proxy/define"
+	com "github.com/linuxdeepin/deepin-network-proxy/com"
+	define "github.com/linuxdeepin/deepin-network-proxy/define"
 	netlink "github.com/linuxdeepin/go-dbus-factory/system/org.deepin.dde.procs1"
 )
 

--- a/cgroups/controls_cgroups.go
+++ b/cgroups/controls_cgroups.go
@@ -16,7 +16,7 @@ import (
 
 // cgroup2 main path
 const (
-	cgroup2Path = "/sys/fs/cgroup/unified"
+	cgroup2Path = "/sys/fs/cgroup"
 	suffix      = ".slice"
 	procsPath   = "cgroup.procs"
 )


### PR DESCRIPTION
deepin v23 mount cgroup v2 at /sys/fs/cgroup/ not at old location
/sys/fs/cgroup/unified.

This program should have the ability to automatically detect cgroup v2
mount point.

This commit is just a workround.

Signed-off-by: black-desk <me@black-desk.cn>
