### PR TITLE
chore: update build dependency to use golang-go only

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends:
  golang-github-stretchr-testify-dev,
  golang-github-miekg-dns-dev,
  golang-github-golang-groupcache-dev,
- golang-go | gccgo-5,
+ golang-go,
 Standards-Version: 4.3.0
 Homepage: http://www.deepin.org
 


### PR DESCRIPTION
Changed the Build-Depends from "golang-go | gccgo-5" to "golang-go" only This simplifies the build dependency by removing the alternative gccgo-5 compiler option
The change ensures consistent use of the standard Go compiler for building the package
This aligns with modern Go development practices where golang-go is the preferred compiler

Influence:
1. Verify package builds successfully with golang-go only
2. Test that all compilation steps complete without errors
3. Ensure no regressions in functionality due to compiler change
4. Confirm package installation works correctly

chore: 更新构建依赖仅使用 golang-go

将 Build-Depends 从 "golang-go | gccgo-5" 改为仅使用 "golang-go" 通过移除备选的 gccgo-5 编译器选项简化了构建依赖
此更改确保在构建包时一致使用标准 Go 编译器
这符合现代 Go 开发实践中 golang-go 作为首选编译器的做法

Influence:
1. 验证仅使用 golang-go 时包构建成功
2. 测试所有编译步骤都能无错误完成
3. 确保由于编译器更改不会导致功能回归
4. 确认包安装正常工作